### PR TITLE
Remove Edgeware frontier image.

### DIFF
--- a/.github/workflows/substrate.yml
+++ b/.github/workflows/substrate.yml
@@ -39,12 +39,6 @@ jobs:
                         package: edgeware-cli
                         name: edgeware
                     -
-                        binary: edgeware
-                        git: https://github.com/hicommonwealth/edgeware-node
-                        branch: edgeware-frontier
-                        package: edgeware-cli
-                        name: edgeware-frontier
-                    -
                         binary: governance-os-node
                         git: https://github.com/NucleiStudio/governance-os
                         branch: master


### PR DESCRIPTION
We no longer support the frontier branch of Edgeware, as it has been merged into master.